### PR TITLE
Fix handling of None-valued option types with P'

### DIFF
--- a/FsToolkit.Postgres.Tests/FsToolkit.Postgres.Tests.fsproj
+++ b/FsToolkit.Postgres.Tests/FsToolkit.Postgres.Tests.fsproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+
+        <IsPackable>false</IsPackable>
+        <GenerateProgramFile>false</GenerateProgramFile>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="nunit" Version="3.12.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Compile Include="PostgresAdoTests.fs" />
+      <None Include="paket.references" />
+    </ItemGroup>
+    
+    <ItemGroup>
+        <ProjectReference Include="..\FsToolkit.Postgres\FsToolkit.Postgres.fsproj" />
+        <ProjectReference Include="..\FsToolkit\FsToolkit.fsproj" />
+    </ItemGroup>
+    <Import Project="..\.paket\Paket.Restore.targets" />
+
+</Project>

--- a/FsToolkit.Postgres.Tests/PostgresAdoTests.fs
+++ b/FsToolkit.Postgres.Tests/PostgresAdoTests.fs
@@ -1,0 +1,19 @@
+﻿namespace FsToolkit.Postgres.Tests
+
+open System
+open NpgsqlTypes
+open Swensen.Unquote
+open NUnit.Framework
+open Newtonsoft.Json.Linq
+open FsToolkit.Postgres
+
+module PostgresAdoTests =
+    
+    [<Test>]
+    let ``P' basic`` () =
+        let p = P'("x", 3)
+        test <@ p.ParameterName = "x" @>
+        test <@ p.NpgsqlValue = (3 :> obj) @>
+        test <@ p.NpgsqlDbType = NpgsqlDbType.Integer @>
+        
+        

--- a/FsToolkit.Postgres.Tests/PostgresAdoTests.fs
+++ b/FsToolkit.Postgres.Tests/PostgresAdoTests.fs
@@ -4,7 +4,6 @@ open System
 open NpgsqlTypes
 open Swensen.Unquote
 open NUnit.Framework
-open Newtonsoft.Json.Linq
 open FsToolkit.Postgres
 
 module PostgresAdoTests =
@@ -20,26 +19,30 @@ module PostgresAdoTests =
     let ``P' type scenarios`` () =
         let scenarios = [
             //string scenarios
-            P'("x", "hello"), NpgsqlDbType.Text
-            P'("x", (null:string)), NpgsqlDbType.Text
+            P'("x", "hello"), (NpgsqlDbType.Text, "hello" :> obj)
+            P'("x", (null:string)), (NpgsqlDbType.Text, DBNull.Value :> obj)
+            P'("x", (None:string option)), (NpgsqlDbType.Text, DBNull.Value :> obj)
+            P'("x", (Some(null):string option)), (NpgsqlDbType.Text, DBNull.Value :> obj)
 
             //integer scenarios
-            P'("x", 3), NpgsqlDbType.Integer
-            P'("x", Some(3)), NpgsqlDbType.Integer
-            P'("x", (None:int option)), NpgsqlDbType.Integer
+            P'("x", 3), (NpgsqlDbType.Integer, 3 :> obj)
+            P'("x", Some(3)), (NpgsqlDbType.Integer, 3 :> obj)
+            P'("x", (None:int option)), (NpgsqlDbType.Integer, DBNull.Value :> obj)
 
             //decimal scenarios
-            P'("x", 3.2m), NpgsqlDbType.Numeric
-            P'("x", Some(3.2m)), NpgsqlDbType.Numeric
-            P'("x", (None:decimal option)), NpgsqlDbType.Numeric
+            P'("x", 3.2m), (NpgsqlDbType.Numeric, 3.2m :> obj)
+            P'("x", Some(3.2m)), (NpgsqlDbType.Numeric, 3.2m :> obj)
+            P'("x", (None:decimal option)), (NpgsqlDbType.Numeric, DBNull.Value :> obj)
 
             //array scenarios
-            P'("x", ["x"; "y"; "z"]), NpgsqlDbType.Array ||| NpgsqlDbType.Text
-            P'("x", seq { "x"; "y"; "z" }), NpgsqlDbType.Array ||| NpgsqlDbType.Text
-            P'("x", Set [ "x"; "y"; "z" ]), NpgsqlDbType.Array ||| NpgsqlDbType.Text
-            P'("x", [| "x"; "y"; "z" |]), NpgsqlDbType.Array ||| NpgsqlDbType.Text
-            P'("x", [1;2;3]), NpgsqlDbType.Array ||| NpgsqlDbType.Integer
+            let xyzArray = [|"x"; "y"; "z"|] :> obj
+            P'("x", ["x"; "y"; "z"]), (NpgsqlDbType.Array ||| NpgsqlDbType.Text, xyzArray)
+            P'("x", seq { "x"; "y"; "z" }), (NpgsqlDbType.Array ||| NpgsqlDbType.Text, xyzArray)
+            P'("x", Set [ "x"; "y"; "z" ]), (NpgsqlDbType.Array ||| NpgsqlDbType.Text, xyzArray)
+            P'("x", [| "x"; "y"; "z" |]), (NpgsqlDbType.Array ||| NpgsqlDbType.Text, xyzArray)
+            P'("x", [1;2;3]), (NpgsqlDbType.Array ||| NpgsqlDbType.Integer, [|1;2;3|] :> obj)
         ]
 
-        for actualDbParam, expectedDbType in scenarios do
+        for actualDbParam, (expectedDbType, expectedDbValue) in scenarios do
             test <@ actualDbParam.NpgsqlDbType = expectedDbType @>
+            test <@ actualDbParam.NpgsqlValue = expectedDbValue @>

--- a/FsToolkit.Postgres.Tests/PostgresAdoTests.fs
+++ b/FsToolkit.Postgres.Tests/PostgresAdoTests.fs
@@ -8,12 +8,38 @@ open Newtonsoft.Json.Linq
 open FsToolkit.Postgres
 
 module PostgresAdoTests =
-    
+
     [<Test>]
     let ``P' basic`` () =
         let p = P'("x", 3)
         test <@ p.ParameterName = "x" @>
         test <@ p.NpgsqlValue = (3 :> obj) @>
         test <@ p.NpgsqlDbType = NpgsqlDbType.Integer @>
-        
-        
+
+    [<Test>]
+    let ``P' type scenarios`` () =
+        let scenarios = [
+            //string scenarios
+            P'("x", "hello"), NpgsqlDbType.Text
+            P'("x", (null:string)), NpgsqlDbType.Text
+
+            //integer scenarios
+            P'("x", 3), NpgsqlDbType.Integer
+            P'("x", Some(3)), NpgsqlDbType.Integer
+            P'("x", (None:int option)), NpgsqlDbType.Integer
+
+            //decimal scenarios
+            P'("x", 3.2m), NpgsqlDbType.Numeric
+            P'("x", Some(3.2m)), NpgsqlDbType.Numeric
+            P'("x", (None:decimal option)), NpgsqlDbType.Numeric
+
+            //array scenarios
+            P'("x", ["x"; "y"; "z"]), NpgsqlDbType.Array ||| NpgsqlDbType.Text
+            P'("x", seq { "x"; "y"; "z" }), NpgsqlDbType.Array ||| NpgsqlDbType.Text
+            P'("x", Set [ "x"; "y"; "z" ]), NpgsqlDbType.Array ||| NpgsqlDbType.Text
+            P'("x", [| "x"; "y"; "z" |]), NpgsqlDbType.Array ||| NpgsqlDbType.Text
+            P'("x", [1;2;3]), NpgsqlDbType.Array ||| NpgsqlDbType.Integer
+        ]
+
+        for actualDbParam, expectedDbType in scenarios do
+            test <@ actualDbParam.NpgsqlDbType = expectedDbType @>

--- a/FsToolkit.Postgres.Tests/paket.references
+++ b/FsToolkit.Postgres.Tests/paket.references
@@ -1,0 +1,4 @@
+NUnit
+NUnit3TestAdapter
+Microsoft.NET.Test.Sdk
+Unquote

--- a/FsToolkit.Postgres/FsToolkit.Postgres.nuspec
+++ b/FsToolkit.Postgres/FsToolkit.Postgres.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>FsToolkit.Postgres</id>
-    <version>5.1.$build_number$</version>
+    <version>5.2.$build_number$</version>
     <description>Postgres helpers, mostly built on top of Npgsql</description>
     <authors>Impefect Foods</authors>
     <license type="expression">MIT</license>
@@ -15,6 +15,6 @@
 	</dependencies>
   </metadata>
   <files>
-    <file src="bin\Release\netstandard2.0\FsToolkit.Postgres.dll" target="lib\netstandard2.0" /> 
+    <file src="bin\Release\netstandard2.0\FsToolkit.Postgres.dll" target="lib\netstandard2.0" />
   </files>
 </package>

--- a/FsToolkit.Postgres/PostgresAdo.fs
+++ b/FsToolkit.Postgres/PostgresAdo.fs
@@ -105,7 +105,7 @@ module PostgresAdo =
         | :? option<DateTime> as v -> P(name, NpgsqlDbType.Timestamp, v.Value)
         | :? option<DateTimeOffset> as v -> P(name, NpgsqlDbType.TimestampTz, v.Value)
         //array-like
-        //TODO Q: if we have a seq of strings that contains nulls, do we need to map to DbNull.Value?
+        //note: null string values in arrays _are_ properly handled
         | :? seq<string> as v -> P(name, NpgsqlDbType.Array ||| NpgsqlDbType.Text, v |> Seq.toArray)
         | :? seq<Guid> as v -> P(name, NpgsqlDbType.Array ||| NpgsqlDbType.Uuid, v |> Seq.toArray)
         | :? seq<Int32> as v -> P(name, NpgsqlDbType.Array ||| NpgsqlDbType.Integer, v |> Seq.toArray)
@@ -166,38 +166,38 @@ module PostgresAdo =
         reader.GetFieldValue<'a>(0)
 
     let read2<'a,'b> (reader:NpgsqlDataReader) =
-        reader.GetFieldValue<'a>(0), 
+        reader.GetFieldValue<'a>(0),
         reader.GetFieldValue<'b>(1)
 
     let read3<'a,'b,'c> (reader:NpgsqlDataReader) =
-        reader.GetFieldValue<'a>(0), 
-        reader.GetFieldValue<'b>(1), 
+        reader.GetFieldValue<'a>(0),
+        reader.GetFieldValue<'b>(1),
         reader.GetFieldValue<'c>(2)
 
     let read4<'a,'b,'c,'d> (reader:NpgsqlDataReader) =
-        reader.GetFieldValue<'a>(0), 
-        reader.GetFieldValue<'b>(1), 
+        reader.GetFieldValue<'a>(0),
+        reader.GetFieldValue<'b>(1),
         reader.GetFieldValue<'c>(2),
         reader.GetFieldValue<'d>(3)
 
     let read5<'a,'b,'c,'d,'e> (reader:NpgsqlDataReader) =
-        reader.GetFieldValue<'a>(0), 
-        reader.GetFieldValue<'b>(1), 
+        reader.GetFieldValue<'a>(0),
+        reader.GetFieldValue<'b>(1),
         reader.GetFieldValue<'c>(2),
         reader.GetFieldValue<'d>(3),
         reader.GetFieldValue<'e>(4)
 
     let read6<'a,'b,'c,'d,'e,'f> (reader:NpgsqlDataReader) =
-        reader.GetFieldValue<'a>(0), 
-        reader.GetFieldValue<'b>(1), 
+        reader.GetFieldValue<'a>(0),
+        reader.GetFieldValue<'b>(1),
         reader.GetFieldValue<'c>(2),
         reader.GetFieldValue<'d>(3),
         reader.GetFieldValue<'e>(4),
         reader.GetFieldValue<'f>(5)
 
     let read7<'a,'b,'c,'d,'e,'f,'g> (reader:NpgsqlDataReader) =
-        reader.GetFieldValue<'a>(0), 
-        reader.GetFieldValue<'b>(1), 
+        reader.GetFieldValue<'a>(0),
+        reader.GetFieldValue<'b>(1),
         reader.GetFieldValue<'c>(2),
         reader.GetFieldValue<'d>(3),
         reader.GetFieldValue<'e>(4),

--- a/FsToolkit.sln
+++ b/FsToolkit.sln
@@ -19,6 +19,8 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FsToolkit.Postgres", "FsToo
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FsToolkit.Json.Tests", "FsToolkit.Json.Tests\FsToolkit.Json.Tests.fsproj", "{88FB536D-8A05-46C4-90B1-F90B752DD902}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FsToolkit.Postgres.Tests", "FsToolkit.Postgres.Tests\FsToolkit.Postgres.Tests.fsproj", "{9BD3E0F4-3A31-45C2-84A3-2C887757EBD4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +47,10 @@ Global
 		{88FB536D-8A05-46C4-90B1-F90B752DD902}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{88FB536D-8A05-46C4-90B1-F90B752DD902}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{88FB536D-8A05-46C4-90B1-F90B752DD902}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9BD3E0F4-3A31-45C2-84A3-2C887757EBD4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9BD3E0F4-3A31-45C2-84A3-2C887757EBD4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9BD3E0F4-3A31-45C2-84A3-2C887757EBD4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9BD3E0F4-3A31-45C2-84A3-2C887757EBD4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This fixes a bug in the `P'` implementation which didn't properly handle None-valued option types. They were - for whatever reason (no doubt related to None representation as null) - matching against the `:? string when v = null` type test case and incorrectly being mapped to `NpgsqlDbType.Text`

Possible places where this may break things (i.e. code depending on the bad behavior):

Suggest
- https://github.com/imperfectproduce/suggest-core/blob/d1ac7590b7b674897f710d9ef93b5eac7a0e7c5e/src/Suggest/DynamicConfig.fs#L31

Atp
- Nothing

Orders
- Nothing