### PR TITLE
Add async versions of npgsql helpers

### DIFF
--- a/FsToolkit.Postgres.Tests/FsToolkit.Postgres.Tests.fsproj
+++ b/FsToolkit.Postgres.Tests/FsToolkit.Postgres.Tests.fsproj
@@ -9,8 +9,7 @@
 
     <ItemGroup>
         <PackageReference Include="nunit" Version="3.12.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/FsToolkit.Postgres/FsToolkit.Postgres.nuspec
+++ b/FsToolkit.Postgres/FsToolkit.Postgres.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>FsToolkit.Postgres</id>
-    <version>5.2.$build_number$</version>
+    <version>5.3.$build_number$</version>
     <description>Postgres helpers, mostly built on top of Npgsql</description>
     <authors>Impefect Foods</authors>
     <license type="expression">MIT</license>

--- a/FsToolkit.Postgres/FsToolkit.Postgres.nuspec
+++ b/FsToolkit.Postgres/FsToolkit.Postgres.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>FsToolkit.Postgres</id>
-    <version>5.3.$build_number$</version>
+    <version>6.0.$build_number$</version>
     <description>Postgres helpers, mostly built on top of Npgsql</description>
     <authors>Impefect Foods</authors>
     <license type="expression">MIT</license>

--- a/FsToolkit/Auto.fs
+++ b/FsToolkit/Auto.fs
@@ -98,6 +98,6 @@ module Auto =
             let! res = workflow
             return! f res }
 
-        ///Start an F# Async<unit> as a C#-compatible Task which is be run by NUnit as a test method.
+        ///Start an F# Async<unit> as a C#-compatible Task which can be run by NUnit as a test method.
         let StartAsyncUnitAsTask (x: Async<unit>) : Task =
             upcast(x |> Async.StartAsTask)

--- a/FsToolkit/Auto.fs
+++ b/FsToolkit/Auto.fs
@@ -4,11 +4,19 @@ open System
 open System.Collections.Generic
 
 [<AutoOpen>]
-module Auto = 
+module Auto =
+    open System.Runtime.ExceptionServices
+
+    ///Re-raise the given exception, preserving stacktrace. This can within async computations
+    ///and other places where `reraise` can't be used. See https://stackoverflow.com/a/7169093
+    let inline reraisePreserve ex =
+        (ExceptionDispatchInfo.Capture ex).Throw ()
+        Unchecked.defaultof<_>
+
     let memoize (f: 'a -> 'b) =
         let cache = System.Collections.Concurrent.ConcurrentDictionary<'a, 'b>()
         fun x -> cache.GetOrAdd(x, f)
-        
+
     ///Coalesce option value
     let inline (|?) x y = defaultArg x y
     ///Coalesce null value
@@ -29,7 +37,7 @@ module Auto =
         let mutable o = Unchecked.defaultof<(^o)>
         if (^o : (static member TryParse : string * ^o byref -> bool) (s, &o)) then
             Some o
-        else 
+        else
             None
 
     let (|Int|_|) x = tryParse x : int option
@@ -38,11 +46,11 @@ module Auto =
     let (|Double|_|) x = tryParse x : Double option
     let (|Bool|_|) x = tryParse x : bool option
     let (|Decimal|_|) x = tryParse x : Decimal option
-    
-    let inline aprintfn fmt = 
+
+    let inline aprintfn fmt =
         Printf.ksprintf (Console.Out.WriteLineAsync>>Async.AwaitTask) fmt
 
-    module UTF8 = 
+    module UTF8 =
         ///String to bytes (utf-8 no BOM)
         let toBytes (text:string) = System.Text.UTF8Encoding(false).GetBytes(text)
         let toString (bytes:byte[]) = System.Text.UTF8Encoding(false).GetString(bytes)
@@ -54,7 +62,7 @@ module Auto =
         /// Trims a string, returning None if string is null or whitespace.
         let trimToOption str =
             if isEmpty str then None
-            else Some (str.Trim())  
+            else Some (str.Trim())
 
     type Uri with
         /// Gets the part of the URI before the last '/' character.

--- a/FsToolkit/Auto.fs
+++ b/FsToolkit/Auto.fs
@@ -2,6 +2,7 @@
 
 open System
 open System.Collections.Generic
+open System.Threading.Tasks
 
 [<AutoOpen>]
 module Auto =
@@ -87,3 +88,16 @@ module Auto =
                 let m = r.Match(input)
                 if m.Success then Some ([for x in m.Groups -> if x.Success then Some(x.Value) else None] |> List.tail)
                 else None
+
+    module Async =
+        let map f workflow = async {
+            let! res = workflow
+            return f res }
+
+        let bind f workflow = async {
+            let! res = workflow
+            return! f res }
+
+        ///Start an F# Async<unit> as a C#-compatible Task which is be run by NUnit as a test method.
+        let StartAsyncUnitAsTask (x: Async<unit>) : Task =
+            upcast(x |> Async.StartAsTask)

--- a/FsToolkit/FsToolkit.nuspec
+++ b/FsToolkit/FsToolkit.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>FsToolkit</id>
-    <version>5.1.$build_number$</version>
+    <version>5.2.$build_number$</version>
     <description>Basic helpers with no dependencies</description>
     <authors>Imperfect Foods</authors>
     <license type="expression">MIT</license>
@@ -15,6 +15,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="bin\Release\netstandard2.0\FsToolkit.dll" target="lib\netstandard2.0" /> 
+    <file src="bin\Release\netstandard2.0\FsToolkit.dll" target="lib\netstandard2.0" />
   </files>
 </package>


### PR DESCRIPTION
This is in support of https://imperfectfoods.atlassian.net/secure/RapidBoard.jspa?rapidView=28&modal=detail&selectedIssue=MER-92

I used https://docs.microsoft.com/en-us/archive/blogs/adonet/using-sqldatareaders-new-async-methods-in-net-4-5 to help decide which ADO.NET async method versions to use (for example, we _don't_ use `GetFieldValueAsync` because we use `ReadAsync` (row) in non-sequential access mode instead).