### PR TITLE
Ensure we dispose of connection `doWithOpenConnAsync`

### DIFF
--- a/FsToolkit.Postgres/PostgresAdo.fs
+++ b/FsToolkit.Postgres/PostgresAdo.fs
@@ -295,7 +295,7 @@ module PostgresAdo =
 
     ///Execute the given function with an asynchronously opened connection which is disposed after completion
     let doWithOpenConnAsync (getConn:unit -> NpgsqlConnection) f = async {
-        let conn = getConn ()
+        use conn = getConn ()
         do! conn.OpenAsync() |> Async.AwaitTask
         let! result = f conn
         do! conn.CloseAsync() |> Async.AwaitTask


### PR DESCRIPTION
Like we learned in ATP service we need to ensure we dispose of any connections we open in case an exception is thrown before we can `CloseAsync`. 