### PR TITLE
Config enhancements to support local overrides

### DIFF
--- a/FsToolkit/Config.fs
+++ b/FsToolkit/Config.fs
@@ -4,7 +4,7 @@ open System
 open System.Configuration
 
 module Config =
-    
+
     let private getAppSetting (name: string) =
         match ConfigurationManager.AppSettings.[name] with
         | null ->
@@ -38,13 +38,13 @@ module Config =
     ///Fails hard if not found.
     let private tryGetSettingDynamic (name: string) =
         let name = name.Trim()
-        let cs = 
+        let cs =
             [getEnvironmentVariable
              getAppSetting
+             getIniSetting AppDomain.CurrentDomain.BaseDirectory "app.ini.local"
+             getIniSetting Environment.CurrentDirectory "app.ini.local"
              getIniSetting AppDomain.CurrentDomain.BaseDirectory "app.ini"
-             getIniSetting Environment.CurrentDirectory "app.ini"
-             getIniSetting AppDomain.CurrentDomain.BaseDirectory "secrets.ini"
-             getIniSetting Environment.CurrentDirectory "secrets.ini"]
+             getIniSetting Environment.CurrentDirectory "app.ini"]
             |> Seq.tryPick (fun getter -> getter(name))
         cs
 
@@ -53,13 +53,13 @@ module Config =
     let tryGetSetting = memoize tryGetSettingDynamic
 
     ///Get config setting, looking in app settings, environment variables, and 'secrets.ini' in that order.
-    let getSettingOrDefault name fallback = 
+    let getSettingOrDefault name fallback =
         match tryGetSetting name with
         | Some cs -> cs
         | None -> fallback
 
     ///Get config setting, looking in app settings, environment variables, and 'secrets.ini' in that order.
-    let getSetting name = 
+    let getSetting name =
         match tryGetSetting name with
         | Some cs -> cs
         | None -> failwithf "Config setting '%s' not found" name

--- a/FsToolkit/Config.fs
+++ b/FsToolkit/Config.fs
@@ -34,8 +34,7 @@ module Config =
             |> Seq.tryHead
         with :? IO.FileNotFoundException -> None
 
-    ///Get config setting, looking in app settings, environment variables, and 'secrets.ini' in that order.
-    ///Fails hard if not found.
+    ///Try-Get config setting, looking in app settings, environment variables, 'app.ini.local', and 'app.ini' in that order.
     let private tryGetSettingDynamic (name: string) =
         let name = name.Trim()
         let cs =
@@ -48,17 +47,19 @@ module Config =
             |> Seq.tryPick (fun getter -> getter(name))
         cs
 
-    ///Get config setting, looking in app settings, environment variables, and 'secrets.ini' in that order.
-    ///Fails hard if not found. Look-up is memoized
+    ///Try-Get config setting, looking in app settings, environment variables, 'app.ini.local', and 'app.ini' in that order.
+    ///Look-up is memoized
     let tryGetSetting = memoize tryGetSettingDynamic
 
-    ///Get config setting, looking in app settings, environment variables, and 'secrets.ini' in that order.
+    ///Get config setting, looking in app settings, environment variables, 'app.ini.local', and 'app.ini' in that order.
+    ///Look-up is memoized. Default ("fallback") is used if not found.
     let getSettingOrDefault name fallback =
         match tryGetSetting name with
         | Some cs -> cs
         | None -> fallback
 
-    ///Get config setting, looking in app settings, environment variables, and 'secrets.ini' in that order.
+    ///Get config setting, looking in app settings, environment variables, 'app.ini.local', and 'app.ini' in that order.
+    ///Look-up is memoized. Fails hard if not found.
     let getSetting name =
         match tryGetSetting name with
         | Some cs -> cs

--- a/FsToolkit/README.md
+++ b/FsToolkit/README.md
@@ -8,7 +8,7 @@ This module implements patterns for reading config values from various sources i
 
 Here is the precedence from which settings are read:
 
-1. environment various
+1. environment variables
 2. traditional `App.config`
 3. `app.ini.local` (intended for non-versioned local overrides)  
 4. `app.ini`

--- a/FsToolkit/README.md
+++ b/FsToolkit/README.md
@@ -1,0 +1,15 @@
+# FsToolkit
+
+Various common helper. Many auto-opened.
+
+## FsToolkit.Config
+
+This module implements patterns for reading config values from various sources in a unified way. The two main usages are `getSetting` (fail hard if not found), `tryGetSetting` (return `None` if setting not found), and `tryGetSettingOrDefault` (get setting with a fallback if not found).
+
+Here is the precedence from which settings are read:
+
+1. environment various
+2. traditional `App.config`
+3. `app.ini.local` (intended for non-versioned local overrides)  
+4. `app.ini`
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FsToolkit
 Helpful packages for everyday F# programming
 
-All packages target `netstandard2.0`. There is one `.nuspec` file per project in the solution (each non-test project is a package).
+All packages target `netstandard2.0`. There is one `.nuspec` file per non-test project in the solution (each non-test project is a package).
 
 Packages are automatically published to nuget.org via circleci build workflow. There are some differences to how we publish packages to nuget.org with circleci compared to how we published packages to our private AppVeyor:
 * we no longer auto-increment the package version patch number in our coninuous integration builds. Package version numbers must be manually set in `.nuspec` files.


### PR DESCRIPTION
1. Remove support for `secrets.ini` - a convention we haven't used in a long time. This will make this release a major version change since we are breaking backwards compat. I doubt it will be a burden for any open source consumers of this API.
2. Add support for `app.ini.local` files which have higher precedence than `app.ini`. The idea is that this will allow localhost overrides to the default, version controlled `app.ini` settings (this is useful for running services locally and changing url's to point to localhosts). Services that support `app.ini.local` should put the file in their .gitignore and .dockerignore files. Bonus if a blank `app.ini.local` file is provide to let developers know it is an option.