### PR TITLE
MER-358: Implement FsToolkit's FastHttp.send (synchronous) in terms of new HttpClient Sync API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: mcr.microsoft.com/dotnet/core/sdk:3.1
+      - image: mcr.microsoft.com/dotnet/sdk:5.0.202-buster-slim
     steps:
       - checkout
       - run:
@@ -11,7 +11,7 @@ jobs:
           command: dotnet test
   pack_and_push:
     docker:
-      - image: mcr.microsoft.com/dotnet/core/sdk:3.1
+      - image: mcr.microsoft.com/dotnet/sdk:5.0.202-buster-slim
     steps:
       - checkout
       - run:

--- a/FsToolkit.Http.Tests/FastHttpTests.fs
+++ b/FsToolkit.Http.Tests/FastHttpTests.fs
@@ -1,0 +1,22 @@
+namespace FsToolkit.Http.Tests
+
+open System
+open Swensen.Unquote
+open NUnit.Framework
+open FsToolkit
+open FsToolkit.Http
+
+module FastHttpTests =
+
+    [<Test>]
+    let ``test sync http request`` () =
+        let request = { FastRequest.Default with Url = "http://www.example.org" }
+        let response = FastHttp.send request
+        test <@ response.Is2xx @>
+
+    [<Test>]
+    let ``test async http request`` () = Async.StartAsyncUnitAsTask <| async {
+        let request = { FastRequest.Default with Url = "http://www.example.org" }
+        let! response = FastHttp.sendAsync request
+        test <@ response.Is2xx @>
+    }

--- a/FsToolkit.Http.Tests/FastHttpTests.fs
+++ b/FsToolkit.Http.Tests/FastHttpTests.fs
@@ -8,15 +8,20 @@ open FsToolkit.Http
 
 module FastHttpTests =
 
+    let inline mkResponseAssertions (response:FastResponse) =
+        test <@ response.Is2xx @>
+        test <@ response.Body.StartsWith("<!doctype html>") @>
+        test <@ response.Headers |> List.contains ("Content-Type", "text/html; charset=utf-8") @>
+
     [<Test>]
     let ``test sync http request`` () =
         let request = { FastRequest.Default with Url = "http://www.example.org" }
         let response = FastHttp.send request
-        test <@ response.Is2xx @>
+        mkResponseAssertions response
 
     [<Test>]
     let ``test async http request`` () = Async.StartAsyncUnitAsTask <| async {
         let request = { FastRequest.Default with Url = "http://www.example.org" }
         let! response = FastHttp.sendAsync request
-        test <@ response.Is2xx @>
+        mkResponseAssertions response
     }

--- a/FsToolkit.Http.Tests/FsToolkit.Http.Tests.fsproj
+++ b/FsToolkit.Http.Tests/FsToolkit.Http.Tests.fsproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net5.0</TargetFramework>
+        <IsPackable>false</IsPackable>
+        <OutputType>Exe</OutputType>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="NUnit" Version="3.12.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+        <PackageReference Include="Unquote" Version="6.0.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Compile Include="FastHttpTests.fs" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\FsToolkit.Http\FsToolkit.Http.fsproj" />
+      <ProjectReference Include="..\FsToolkit\FsToolkit.fsproj" />
+    </ItemGroup>
+
+</Project>

--- a/FsToolkit.Http/FsToolkit.Http.fsproj
+++ b/FsToolkit.Http/FsToolkit.Http.fsproj
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <NuspecFile>FsToolkit.Http.nuspec</NuspecFile>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.7.2" />
+    <PackageReference Update="FSharp.Core" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="FastHttp.fs" />

--- a/FsToolkit.Http/FsToolkit.Http.fsproj
+++ b/FsToolkit.Http/FsToolkit.Http.fsproj
@@ -7,7 +7,7 @@
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="4.7.2" />
+    <PackageReference Update="FSharp.Core" Version="4.7.2" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="FastHttp.fs" />

--- a/FsToolkit.Http/FsToolkit.Http.nuspec
+++ b/FsToolkit.Http/FsToolkit.Http.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Imperfect.FsToolkit.Http</id>
-    <version>5.1.143</version>
+    <version>6.0.0-rc.1</version>
     <description>Http helpers, mostly built on top of HttpClient</description>
     <authors>Imperfect Foods</authors>
     <license type="expression">MIT</license>
@@ -14,6 +14,6 @@
 	</dependencies>
   </metadata>
   <files>
-    <file src="bin\Release\netstandard2.0\FsToolkit.Http.dll" target="lib\netstandard2.0" />
+    <file src="bin\Release\net5.0\FsToolkit.Http.dll" target="lib\net5.0" />
   </files>
 </package>

--- a/FsToolkit.Http/FsToolkit.Http.nuspec
+++ b/FsToolkit.Http/FsToolkit.Http.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Imperfect.FsToolkit.Http</id>
-    <version>6.0.0-rc.1</version>
+    <version>6.0.0-rc.2</version>
     <description>Http helpers, mostly built on top of HttpClient</description>
     <authors>Imperfect Foods</authors>
     <license type="expression">MIT</license>

--- a/FsToolkit.Http/FsToolkit.Http.nuspec
+++ b/FsToolkit.Http/FsToolkit.Http.nuspec
@@ -8,8 +8,8 @@
     <license type="expression">MIT</license>
 	<projectUrl>https://github.com/imperfectproduce/FsToolkit</projectUrl>
 	<dependencies>
-      <group targetFramework="netstandard2.0">
-		<dependency id="FSharp.Core" version="4.7.2" />
+      <group targetFramework="net5.0">
+		<dependency id="FSharp.Core" version="5.0.0" />
       </group>
 	</dependencies>
   </metadata>

--- a/FsToolkit.Http/packages.lock.json
+++ b/FsToolkit.Http/packages.lock.json
@@ -1,26 +1,12 @@
 {
   "version": 1,
   "dependencies": {
-    ".NETStandard,Version=v2.0": {
+    ".NETCoreApp,Version=v5.0": {
       "FSharp.Core": {
         "type": "Direct",
-        "requested": "[4.7.2, )",
-        "resolved": "4.7.2",
-        "contentHash": "w3XFVTnyZUbC8e2QT6a85ern6y7eQPPk+MYemz1FP0iBfgZcembL+wmo5cIZ1kxB8jfoXC8Q9KVkOMsGpkBKbA=="
-      },
-      "NETStandard.Library": {
-        "type": "Direct",
-        "requested": "[2.0.3, )",
-        "resolved": "2.0.3",
-        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0"
-        }
-      },
-      "Microsoft.NETCore.Platforms": {
-        "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
+        "requested": "[5.0.0, )",
+        "resolved": "5.0.0",
+        "contentHash": "iHoYXA0VaSQUONGENB1aVafjDDZDZpwu39MtaRCTrmwFW/cTcK0b2yKNVYneFHJMc3ChtsSoM9lNtJ1dYXkHfA=="
       }
     }
   }

--- a/FsToolkit.Json.Tests/FsToolkit.Json.Tests.fsproj
+++ b/FsToolkit.Json.Tests/FsToolkit.Json.Tests.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/FsToolkit.Json/FsToolkit.Json.fsproj
+++ b/FsToolkit.Json/FsToolkit.Json.fsproj
@@ -7,7 +7,7 @@
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="4.7.2" />
+    <PackageReference Update="FSharp.Core" Version="4.7.2" />
     <PackageReference Include="newtonsoft.json" Version="12.0.3" />
   </ItemGroup>
   <ItemGroup>

--- a/FsToolkit.Postgres.Tests/FsToolkit.Postgres.Tests.fsproj
+++ b/FsToolkit.Postgres.Tests/FsToolkit.Postgres.Tests.fsproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-      <TargetFramework>netcoreapp3.1</TargetFramework>
+      <TargetFramework>net5.0</TargetFramework>
       <IsPackable>false</IsPackable>
       <OutputType>Exe</OutputType>
     </PropertyGroup>

--- a/FsToolkit.Postgres/FsToolkit.Postgres.fsproj
+++ b/FsToolkit.Postgres/FsToolkit.Postgres.fsproj
@@ -7,7 +7,7 @@
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="4.7.2" />
+    <PackageReference Update="FSharp.Core" Version="4.7.2" />
     <PackageReference Include="Npgsql" Version="4.1.5" />
   </ItemGroup>
   <ItemGroup>

--- a/FsToolkit.sln
+++ b/FsToolkit.sln
@@ -15,6 +15,8 @@ Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FsToolkit.Json.Tests", "FsT
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FsToolkit.Postgres.Tests", "FsToolkit.Postgres.Tests\FsToolkit.Postgres.Tests.fsproj", "{9BD3E0F4-3A31-45C2-84A3-2C887757EBD4}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FsToolkit.Http.Tests", "FsToolkit.Http.Tests\FsToolkit.Http.Tests.fsproj", "{8F1D6854-6AC4-42AE-859F-4D5CC5ABDA5A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +47,10 @@ Global
 		{9BD3E0F4-3A31-45C2-84A3-2C887757EBD4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9BD3E0F4-3A31-45C2-84A3-2C887757EBD4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9BD3E0F4-3A31-45C2-84A3-2C887757EBD4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8F1D6854-6AC4-42AE-859F-4D5CC5ABDA5A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8F1D6854-6AC4-42AE-859F-4D5CC5ABDA5A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8F1D6854-6AC4-42AE-859F-4D5CC5ABDA5A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8F1D6854-6AC4-42AE-859F-4D5CC5ABDA5A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/FsToolkit/FsToolkit.fsproj
+++ b/FsToolkit/FsToolkit.fsproj
@@ -7,7 +7,7 @@
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="4.7.2" />
+    <PackageReference Update="FSharp.Core" Version="4.7.2" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7" />
   </ItemGroup>
   <ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.0",
+    "version": "5.0.202",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
See https://imperfectfoods.atlassian.net/browse/MER-358 for context

- retarget FsToolkit.Http to net5.0 framework version so we have access to new `HttpClient.Send` API
- re-implement `FastHttp.send` to be in terms of new `HttpClient.Send` instead of using "sync-over-async" pattern
- add `FsToolkit.Http.Tests` project with some automated tests to confirm same expected response from sync and async versions

We also implement modern `HttpClient` instantiations patterns

- Instead of using a global `HttpClientHandler` and global `HttpClient` instance, we use a global `SocketsHttpHandler` instance and per-request `HttpClient` instances per recommendation here: https://docs.microsoft.com/en-us/aspnet/core/fundamentals/http-requests?view=aspnetcore-3.1#alternatives-to-ihttpclientfactory
- The above should resolve a known issue we've encountered before with .NET apps not responding to DNS refreshes (by configuring `PooledConnectionLifetime` to 10 minutes on the `SocketsHttpHandler`
- We remove the `optimize ()` function since it used to set properties on the deprecated `ServicePointManager` global instance. Equivalent properties are now set either on `SocketsHttpHandler` or `HttpClient` properties.