### PR TITLE
One-way JSON client serializer

### DIFF
--- a/FsToolkit.Json.Tests/SerializationTests.fs
+++ b/FsToolkit.Json.Tests/SerializationTests.fs
@@ -12,7 +12,7 @@ module SerializtionTests =
         type EnumDu =
             | A
             | B
-        
+
         type JsonObj1<'a> = { Field1: 'a }
         type JsonObj2<'a> = { FieldA: 'a option }
         [<Test>]
@@ -69,7 +69,63 @@ module SerializtionTests =
                 let json = serialize Client value
                 let value' = deserialize Client json
                 test <@ value = value' @>
+    module OneWayToClient =
 
+        [<Test>]
+        let ``deserializing is prohibited `` () =
+            raises<FsToolkit.Json.Converters.JsonDeserializingNotSupportedException>
+                <@
+                    let json = """{"foo":"bar"}"""
+                    deserialize OneWayToClient json
+                @>
+        type OneWayDuCaseNestedDu =
+            | OneWayDuCaseNestedDuCaseEnumLike
+            | OneWayDuCaseNestedDuCaseInt of int
+        type OneWayDu =
+            | OneWayDuCaseInt of int
+            | OneWayDuCaseBool of bool
+            | OneWayDuCaseTuple of int * string
+            | OneWayDuCaseList of int list
+            | OneWayDuCaseSeq of int seq
+            | OneWayDuCaseMap of Map<string, int>
+            | OneWayDuCaseEnumLike
+            | OneWayDuCaseRecord of {| foo: string; bar: int |}
+            | OneWayDuCaseOption of int option
+            | OneWayDuCaseNestedDu of OneWayDuCaseNestedDu
+        [<Test>]
+
+        let ``serialize client DU values and strip out cases `` () =
+            let values = [
+                OneWayDuCaseInt(3)
+                OneWayDuCaseBool true
+                OneWayDuCaseTuple(3,"4")
+                OneWayDuCaseList [3]
+                OneWayDuCaseList [3; 4]
+                OneWayDuCaseSeq ([3; 4] |> List.toSeq)
+                OneWayDuCaseMap (Map [ ("foo", 3); ("bar", 4) ])
+                OneWayDuCaseEnumLike
+                OneWayDuCaseRecord({|foo = "fooValue"; bar = 3|})
+                OneWayDuCaseOption (Some 3)
+                OneWayDuCaseOption None
+                OneWayDuCaseNestedDu (OneWayDuCaseNestedDuCaseInt 3)
+            ]
+            let expectedResults = [
+                "3"
+                "true"
+                """[3,"4"]"""
+                "[3]"
+                "[3,4]"
+                "[3,4]"
+                """{"bar":4,"foo":3}"""
+                "\"OneWayDuCaseEnumLike\""
+                """{"bar":3,"foo":"fooValue"}"""
+                "3"
+                "null"
+                "3"
+            ]
+            for (value, expected) in (List.zip values expectedResults) do
+                let json = serialize OneWayToClient value
+                test <@ expected = json @>
 
     module Storage =
         type Du1 =

--- a/FsToolkit.Json/README.md
+++ b/FsToolkit.Json/README.md
@@ -22,9 +22,10 @@ A set of `JsonConverter` implementations for better client and / or storage seri
   - `TupleConverter` serializes tuples as arrays, e.g. `(2, "3") -> [2, "3"]`
   - `StorageDUConverter` serializes DUs as flat objects with explicit fields names when given, and normalized auto-field names otherwise
   - `ClientDUConverter` serializes DUs as flat objects with explicit field names when given. "enum-like" DUs (all cases lack fields) are serialized as case-name strings. Single-field DUs without explicit field name are serialized with `value` field name.
+  - `OneWayToJsonDUConverter` serializes DUs as flat objects using only case values. "enum-like" cases are serialized as case-name strings.  This converter cannot be used to deserialize 
   
 ## FsToolkit.Json.Serialization
 
 An _opinionated_ set of helpers for serialization and deserializing exotic F# types.
 
-Distinguishes between three types of serialization targets: Client, Storage, and Transfer. Provides `ClientIgnore` and `StorageIgnore` attributes for controlling fields used in object serialization.
+Distinguishes between four types of serialization targets: Client, OneWayToClient, Storage, and Transfer. Provides `ClientIgnore` and `StorageIgnore` attributes for controlling fields used in object serialization.


### PR DESCRIPTION
Recently I've been experiencing some heartache while serializing "non-enum-like" Discriminated Unions.  With the existing `Client` serializer, DUs will get converted like so:
```
type ExampleDu =
        | ExampleDuCase1 of {|foo: string|}
        | ExampleDuCase2
    
    let foo = ExampleDuCase1 {|foo = "bar"|}
//  serializes to: {"case": "ExampleDuCase1, "value": {"foo": "bar"}}
```
I've been able to work-around this a little bit by swapping record DU cases with tuples.  Tuples will remove the `value` nesting but the `case` property will still pollute the object.   
```
type ExampleDu =
        | ExampleDuCase1 of foo: string * baz: string
        | ExampleDuCase2
    
    let foo = ExampleDuCase1 ("bar", "qux")
//  serializes to: {"case": "ExampleDuCase1", "foo": "bar", "baz": "qux"}
```

This PR introduces a "one-way" serializer setting intended to generate a clean and flat JSON representation by abandoning the ability to round-trip serialize and deserialize.  This serializer pairs best with outbound DTO types where the type can be serialized prior to hitting the wire.  While it's not the most common to have DUs on DTO types I think they have there place.  One example would be some piece of business logic that creates a DU consisting of differing fields that need to be updated on a remote PATCH endpoint.

Oh and apologies for the whitespace changes.  Kindly hit the ignore whitespace button in GH :) 