### PR TITLE
DO-778: Add support for app.ini.secrets

### DIFF
--- a/FsToolkit/Config.fs
+++ b/FsToolkit/Config.fs
@@ -42,6 +42,8 @@ module Config =
              getAppSetting
              getIniSetting AppDomain.CurrentDomain.BaseDirectory "app.ini.local"
              getIniSetting Environment.CurrentDirectory "app.ini.local"
+             getIniSetting AppDomain.CurrentDomain.BaseDirectory "app.ini.secrets"
+             getIniSetting Environment.CurrentDirectory "app.ini.secrets"
              getIniSetting AppDomain.CurrentDomain.BaseDirectory "app.ini"
              getIniSetting Environment.CurrentDirectory "app.ini"]
             |> Seq.tryPick (fun getter -> getter(name))

--- a/FsToolkit/FsToolkit.nuspec
+++ b/FsToolkit/FsToolkit.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Imperfect.FsToolkit</id>
-    <version>6.0.0</version>
+    <version>7.0.0-alpha1</version>
     <description>Basic helpers</description>
     <authors>Imperfect Foods</authors>
     <license type="expression">MIT</license>

--- a/FsToolkit/README.md
+++ b/FsToolkit/README.md
@@ -11,5 +11,6 @@ Here is the precedence from which settings are read:
 1. environment variables
 2. traditional `App.config`
 3. `app.ini.local` (intended for non-versioned local overrides)  
-4. `app.ini`
+4. `app.ini.secrets` (intended for script generate secrets)  
+5. `app.ini`
 

--- a/README.md
+++ b/README.md
@@ -16,5 +16,6 @@ Recommended workflow for publishing new package versions:
 
 ## Project-specific Readme's
 
+- [FsToolkit](https://github.com/relayfoods/FsToolkit/tree/master/FsToolkit)
 - [FsToolkit.Json](https://github.com/relayfoods/FsToolkit/tree/master/FsToolkit.Json)
 


### PR DESCRIPTION
Per discussion with DevOps, this PR adds support for `app.ini.secrets` files. In our use case,

- `app.ini.secrets` will be interpolated from `app.ini`using a bash script that pulls from our secrets vault. In this way, `app.ini` will no longer contain any secrets or environment variables that can vary by environment for that matter
- the precedence of `app.ini.secrets` comes after `app.ini.local` but before `app.ini` which allows us to continue to override environment variables locally, but continue to use `app.ini` for static environment variables that are not generated into `app.ini.secrets` (which also allows us to use `app.ini` files in test projects with "static" env var that differ from what we use when running apps locally.
- `app.ini.secrets` should be added to .gitignore just like we do with `app.ini.local` to ensure secrets don't accidentally get committed to version control