### PR TITLE
MER-951: Add StatusCode to created HttpRequestException

### DIFF
--- a/FsToolkit.Http/FastHttp.fs
+++ b/FsToolkit.Http/FastHttp.fs
@@ -70,7 +70,7 @@ type FastResponse = {
     ///Raises an HttpRequestException with details about the FastResponse
     member this.Fail() =
         let msg = sprintf "The remote server response was rejected by caller: %i. Response from %s: %s" this.StatusCode this.RequestUrl this.Body
-        raise <| HttpRequestException(msg)
+        raise <| HttpRequestException(msg, null, enum<HttpStatusCode>(this.StatusCode))
     ///Raises an HttpRequestException is the StatusCode is outside of the 200-range
     member this.Ensure2xx() =
         if this.Is2xx |> not then


### PR DESCRIPTION
When `Ensure2xx=true`, the HttpRequestException that is thrown used to not contain a StatusCode, which would be useful to have sometimes. This PR adds that in.

Side note: This project is still using .NET 5, does anyone know the LOE to upgrade to .NET 6?